### PR TITLE
Adding ensure event order

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[amazonica "0.3.112"]
                  [aero "1.1.2"]
+                 [baldr "0.1.1"]
                  [clj-time "0.14.0"]
-                 [org.clojure/clojure "1.9.0-beta1"]]
+                 [org.clojure/clojure "1.9.0-beta2"]]
+
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}}
   :main kixi.event-replay)

--- a/src/kixi/event_replay/ensure_event_order.clj
+++ b/src/kixi/event_replay/ensure_event_order.clj
@@ -1,0 +1,88 @@
+(ns kixi.event-replay.ensure-event-order
+  "Our Events contain all the mutations for our domain, as such they must be processed in order.
+  This order is maintained until they reach the AWS Firehose that is delivering them to S3, therefore
+  when reading them back in for processing we have to ensure the order is maintained.
+
+  For now we will throw an exception if this happens, but there is a prototype windowing ordering
+  implementation to try should we encounter the problem"
+  (:require [clj-time.core :as t]
+            [clj-time.format :as f]))
+
+(def parse-timestamp
+  (partial f/parse (f/formatter :basic-date-time)))
+
+(defn event->created-time
+  [event]
+  (parse-timestamp
+   (or (:kixi.comms.event/created-at event)
+       (:kixi.event/created-at event))))
+
+(defn compare-event-created-times
+  [f s]
+  (compare (event->created-time f)
+           (event->created-time s)))
+
+(defn exception-on-out-of-order-event
+  [xf]
+  (let [state (atom nil)]
+    (fn
+      ([] (xf))
+      ([result]
+       (->> @state
+            (xf result)
+            xf))
+      ([result event]
+       (if (nil? @state)
+         (do (reset! state event)
+             result)
+         (if-not (pos? (compare-event-created-times @state event))
+           (let [release @state]
+             (reset! state event)
+             (xf result release))
+           (throw (ex-info "Event created time stamps out of order"
+                           {:first @state
+                            :second event}))))))))
+
+
+(defn event-created-ordered-set
+  ([]
+   (event-created-ordered-set []))
+  ([ks]
+   (apply (partial sorted-set-by
+                   (comp #(if (zero? %)
+                            -1 %)
+                         compare-event-created-times))
+          ks)))
+
+;This doesn't perform very well, but should be enough to prove the theory on a discovered out of order file
+(defn time-windowed-ordering
+  [sort-window-interval]
+  (fn
+    [xf]
+    (let [state (atom (event-created-ordered-set))]
+      (fn
+        ([] (xf))
+        ([result]
+         (xf
+          (reduce
+           (fn [r e]
+             (xf r e))
+           result
+           @state)))
+        ([result event]
+         (if (empty? @state)
+           (do (swap! state conj event)
+               result)
+           (let [event-dt-minus-window (t/minus (event->created-time event)
+                                                sort-window-interval)
+                 [releasable-events keep-events] (split-with
+                                                  #(t/before? (event->created-time %)
+                                                              event-dt-minus-window)
+                                                  @state)]
+             (reset! state (conj (event-created-ordered-set keep-events)
+                                 event))
+             (reduce
+              (fn [r e]
+                (xf r e))
+              result
+              releasable-events))))))))

--- a/src/kixi/event_replay/s3_object_summary_>nippy_encoded_events.clj
+++ b/src/kixi/event_replay/s3_object_summary_>nippy_encoded_events.clj
@@ -1,11 +1,15 @@
 (ns kixi.event-replay.s3-object-summary->nippy-encoded-events
-  (:require [amazonica.aws.s3 :as s3]))
+  (:require [amazonica.aws.s3 :as s3]
+            [baldr.core :as baldr])
+  (:import [java.io InputStream]))
 
 (defn s3-object-summary->nippy-encoded-events
+  "Eagerly consumes objects contents, through baldr-seq"
   [{:keys [s3-base-dir]
     :as config}
    s3-object-summary]
   (let [s3-object (s3/get-object :bucket-name s3-base-dir
                                  :key (:key s3-object-summary))]
-    ;;TODO parse whole object through baldr-seq, doall and close object stream
-    ))
+    (with-open [^InputStream in (:object-content s3-object)]
+      (doall
+       (baldr/baldr-seq in)))))

--- a/test/kixi/event_replay/ensure_event_order_test.clj
+++ b/test/kixi/event_replay/ensure_event_order_test.clj
@@ -1,0 +1,94 @@
+(ns kixi.event-replay.ensure-event-order-test
+  (:require [clj-time.coerce :as c]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [clojure.spec.alpha :as spec]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test :refer :all]
+            [kixi.event-replay.ensure-event-order :as sut]
+            [clojure.test.check :as tc]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.properties :as prop]))
+
+(comment "Cider bug https://github.com/clojure-emacs/cider/issues/1841 means [clojure.test.check :as tc] being required without use")
+
+(def generative-iterations 1000)
+
+(def timestamp-gen
+  (gen/fmap
+   (comp (partial f/unparse (f/formatter :basic-date-time))
+         c/from-date)
+   (spec/gen (spec/inst-in #inst "2017-10-19T00:00:00.000" #inst "2017-10-19T01:00:00.000"))))
+
+(def event-gen
+  (gen/map (gen/elements [:kixi.comms.event/created-at :kixi.event/created-at])
+           timestamp-gen
+           {:num-elements 1}))
+
+(def events-gen
+  (gen/vector event-gen
+              1 50))
+
+(defn exception-on-out-of-order-event-test
+  [events]
+  (into []
+   sut/exception-on-out-of-order-event
+   events))
+
+(defspec exception-on-out-of-order-event
+  generative-iterations
+  (prop/for-all [events events-gen]
+                (if (= (sort-by sut/event->created-time events)
+                       events)
+                  (= (exception-on-out-of-order-event-test events)
+                     events)
+                  (try
+                    (exception-on-out-of-order-event-test events)
+                    false
+                    (catch Exception e
+                      true)))))
+
+
+(def ordering-window (t/minutes 5))
+
+(defn within-reverse-window
+  [ft st]
+  (t/within? (t/minus ft ordering-window)
+             ft
+             st))
+
+(defn after-unless-out-of-window
+  "Needs to be able to detect the reason for an out of order timestamp, probably by scanning ahead and finding a suspected window breaking timestamp"
+  [events]
+  (reduce
+   (fn [f s]
+     (let [ft (sut/event->created-time f)
+           st (sut/event->created-time s)]
+       (if (or (t/after? st ft)
+               (t/equal? st ft))
+         s
+         (if (within-reverse-window ft st)
+           (reduced false)
+           s))))
+   events))
+
+(spec/fdef time-windowed-ordering-test
+           :args (spec/with-gen vector?
+                   #(gen/vector events-gen
+                                1))
+           :fn (fn [{:keys [args ret]}]
+                 (= (count (first args))
+                    (count ret)))
+           :ret vector?) ;no assertion, need effective after-unless-out-of-window
+
+(defn time-windowed-ordering-test
+  [events]
+  (into []
+        (sut/time-windowed-ordering ordering-window)
+        events))
+
+(deftest check-time-windowed-ordering-test
+  (is (every? (comp nil? :failure)
+              (stest/check `time-windowed-ordering-test
+                           {:max-size generative-iterations}))))


### PR DESCRIPTION
There are two ensure event order functions made available for the main
pipeline.

The first, and curretly used, function throws an exception when an out
of order event is discovered. We don't know exactly how bad this issue
will be, but this will prevent us experiencing the nasty effects when
it crops up.

The second is a suspected solution to the problem. The implementation
appears to work, extensive time has been with it, but writing a
function capable of truely determining it in the generator framework
is taking too long. Therefore, given that we don't expect this to
occur for some time and we will be alerted to an instance, it's being
moth balled here until it's needed.

There's a small change in event_replay name space, but that's unused yet, same with the baldr reader.