### PR TITLE
Byte arrays need wrapping in byte buffers

### DIFF
--- a/src/kixi/event_replay/kinesis_send_events.clj
+++ b/src/kixi/event_replay/kinesis_send_events.clj
@@ -73,11 +73,18 @@
       (assoc :data (:event event))
       (dissoc :event)))
 
+(defn wrap-byte-buffers
+  [event]
+  (update event
+          :data
+          #(java.nio.ByteBuffer/wrap %)))
+
 (defn send-event-batches
   [{{:keys [batch-size]}
     :kinesis
     :as config}]
   (comp
    (map rename-event->data)
+   (map wrap-byte-buffers)
    (partition-all batch-size)
    (map (partial send-batch config))))


### PR DESCRIPTION
Our events are byte arrays, but the kinesis library only leaves them
alone if they are wrapped in nio.ByteBuffers and we need them left alone!