### PR TITLE
Swaps in ordering by time windows

### DIFF
--- a/src/kixi/event_replay.clj
+++ b/src/kixi/event_replay.clj
@@ -5,7 +5,7 @@
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [clojure.pprint :refer [pprint]]
-            [kixi.event-replay.ensure-event-order :refer [exception-on-out-of-order-event]]
+            [kixi.event-replay.ensure-event-order :refer [time-windowed-ordering exception-on-out-of-order-event]]
             [kixi.event-replay.hour->s3-object-summaries
              :refer
              [hour->s3-object-summaries]]
@@ -62,6 +62,7 @@
   (comp (mapcat (partial hour->s3-object-summaries config))
         (mapcat (partial s3-object-summary->nippy-encoded-events config))
         (map nippy/thaw)
+        time-windowed-ordering
         exception-on-out-of-order-event
         (send-event-batches config)))
 


### PR DESCRIPTION
The ordering exception has discovered an out of order pair of
events. This change swaps in the time window ordering function, hard
coded to 10 milliseconds, the discovered pair are out by 3.

The exception throwing orderer will come after, so we'll know if this
doesn't work.